### PR TITLE
测试了arm64的支持，解决了一些项目文件中存在的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 lib
 
 .vs/
+src/lib

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ obj
 bin
 *.dll
 lib
+
+.vs/

--- a/Translater.csproj
+++ b/Translater.csproj
@@ -1,5 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk"
-         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <TargetFramework>net7.0-windows</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -17,7 +16,7 @@
         <Reference Include="Wox.Infrastructure">
             <HintPath>lib/Wox.Infrastructure.dll</HintPath>
         </Reference>
-        <Reference Include="Microsoft.PowerToys.Settings.UI.Library">
+        <Reference Include="PowerToys.Settings.UI.Lib">
             <HintPath>lib/PowerToys.Settings.UI.Lib.dll</HintPath>
         </Reference>
         <Reference Include="PowerToys.Common.UI">
@@ -26,31 +25,20 @@
         <Reference Include="PowerToys.ManagedCommon">
             <HintPath>lib/PowerToys.ManagedCommon.dll</HintPath>
         </Reference>
-        <None Include="./plugin.json"
-              CopyToOutputDirectory="PreserveNewest" />
-        <None Include="./Images/translater.dark.png"
-              CopyToOutputDirectory="PreserveNewest"
-              Link="Images\translater.dark.png" />
-        <None Include="./Images/translater.light.png"
-              CopyToOutputDirectory="PreserveNewest"
-              Link="Images\translater.light.png" />
+        <None Include="./plugin.json" CopyToOutputDirectory="PreserveNewest" />
+        <None Include="./Images/translater.dark.png" CopyToOutputDirectory="PreserveNewest" Link="Images\translater.dark.png" />
+        <None Include="./Images/translater.light.png" CopyToOutputDirectory="PreserveNewest" Link="Images\translater.light.png" />
     </ItemGroup>
-    <Target Name="Movefiles"
-            AfterTargets="Build">
+    <Target Name="Movefiles" AfterTargets="Build">
         <ItemGroup>
             <MySourceFiles Include="./plugin.json" />
             <MySourceFiles Include="$(OutputPath)Translator.dll" />
             <ImagesFile Include="$(OutputPath)Images\*.*" />
         </ItemGroup>
-        <Copy SourceFiles="@(MySourceFiles)"
-              DestinationFolder="./bin/Translator" />
-        <Copy SourceFiles="@(ImagesFile)"
-              DestinationFolder="./bin/Translator/Images" />
+        <Copy SourceFiles="@(MySourceFiles)" DestinationFolder="./bin/Translator" />
+        <Copy SourceFiles="@(ImagesFile)" DestinationFolder="./bin/Translator/Images" />
     </Target>
-    <Target Name="ZipOutput"
-            AfterTargets="Pack">
-        <ZipDirectory SourceDirectory="./bin/Translator"
-                      DestinationFile="./bin/Translator.zip"
-                      Overwrite="true" />
+    <Target Name="ZipOutput" AfterTargets="Pack">
+        <ZipDirectory SourceDirectory="./bin/Translator" DestinationFile="./bin/Translator.zip" Overwrite="true" />
     </Target>
 </Project>

--- a/Translater.sln
+++ b/Translater.sln
@@ -11,8 +11,8 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{85C26C28-8505-4154-B24A-9B82F296E755}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{85C26C28-8505-4154-B24A-9B82F296E755}.Debug|Any CPU.Build.0 = Debug|x64
+		{85C26C28-8505-4154-B24A-9B82F296E755}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{85C26C28-8505-4154-B24A-9B82F296E755}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{85C26C28-8505-4154-B24A-9B82F296E755}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{85C26C28-8505-4154-B24A-9B82F296E755}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection


### PR DESCRIPTION
不知在您的机器上如何，在我尝试在arm64的机器上编译的时候，必须将Translater.csproj中，对lib/PowerToys.Settings.UI.Lib.dll的引用改为如下才能正常工作。
```xml
        <Reference Include="PowerToys.Settings.UI.Lib">
            <HintPath>lib/PowerToys.Settings.UI.Lib.dll</HintPath>
        </Reference>
```

在这之后我也在我的x64机器上进行了尝试，这样改是能正常工作的。

这里也附上我编译的arm64 release版本：
[Translator-arm64.zip](https://github.com/N0I0C0K/PowerTranslator/files/11085536/Translator-arm64.zip)


VS2022自动进行了项目文件的格式化，此外我添加了一些忽略项到.gitignore。