### PR TITLE
Add Italian and Hebrew language options

### DIFF
--- a/src/Translator.cs
+++ b/src/Translator.cs
@@ -43,8 +43,8 @@ namespace Translator
         private object preQueryLock = new Object();
 
         // settings
-        private static readonly List<string> languagesOptions = new List<string> { "auto", "Chinese (Simplified)", "Chinese (Traditional)", "English", "Japanese", "Korean", "Russian", "French", "Spanish", "Arabic", "German" };
-        private static readonly List<string> languagesKeys = new List<string> { "auto", "zh-CHS", "zh-CHT", "en", "ja", "ko", "ru", "fr", "es", "ar", "de" };
+        private static readonly List<string> languagesOptions = new List<string> { "auto", "Chinese (Simplified)", "Chinese (Traditional)", "English", "Japanese", "Korean", "Russian", "French", "Spanish", "Arabic", "German", "Italian", "Hebrew" };
+        private static readonly List<string> languagesKeys = new List<string> { "auto", "zh-CHS", "zh-CHT", "en", "ja", "ko", "ru", "fr", "es", "ar", "de", "it", "he" };
         private static readonly List<PluginAdditionalOption> additionOptions = GetAdditionalOptions();
         private string defaultLanguageKey = "auto";
         private bool delayedExecution = false;


### PR DESCRIPTION
Hey, I wanted to use Italian so I added it myself. I also added Hebrew because I saw a comment asking for it.

For other contributors looking for more languages, refer to the language support table [here](https://ai.youdao.com/DOCSIRMA/html/trans/api/wbfy/index.html#section-9) (scroll down a bit)

Thank you for this very useful plugin!