### PR TITLE
Add Indonesian language support

### DIFF
--- a/src/Helper/SettingHelper.cs
+++ b/src/Helper/SettingHelper.cs
@@ -18,7 +18,8 @@ namespace Translator
             { "ar", "Arabic" },
             { "de", "German" },
             { "it", "Italian" },
-            { "he", "Hebrew" }
+            { "he", "Hebrew" },
+            { "id", "Indonesian" }
         };
 
         public static readonly List<ResultItem> languageList = Languages.Select((val) => new ResultItem { Title = val.Key, SubTitle = val.Value }).ToList();


### PR DESCRIPTION
This PR adds support for my language (indonesian - id) to the translator.

Changes:
- Added "id": "Indonesian" to the Languages dictionary in src/Helper/SettingHelper.cs.

Context:
[The Youdao translation API](https://ai.youdao.com/DOCSIRMA/html/trans/api/wbfy/index.html#section-12) supports Indonesian with the code id. This change exposes that capability.